### PR TITLE
country adjectives + other small changes

### DIFF
--- a/main.py
+++ b/main.py
@@ -52,7 +52,7 @@ def generate_plate():
 
     plate = plate_options[country]()
     plate.image_plate()
-    dictsw = plate.dict_sw()
+    dictsw = plate.dictsw
     plate_number = plate.plate_number
     back_matter(plate_number,dictsw)
     plate_numbers.append(plate_number)

--- a/plate.py
+++ b/plate.py
@@ -25,14 +25,18 @@ class LicensePlate:
         self.plate_number = plate_number
         self.country = country
         self.vehicle = 'car' # making every vehicle a car for now. May add support to bikes in the future.
+        self.dictsw = {
+            'country':country_sw(self.country),
+            'number':self.translate_number()
+        }
     
     # basic to-string method. Goal to create code that generates a picture of the plate eventually
     def __str__(self):
         return (f'number: {self.plate_number},country:{self.country},vehicle:{self.vehicle}')
     
-    # dict of all properties translated to Swedish. On every country to implement different translations
-    def dict_sw(self):
-        return {}
+    # just a template for now. Will override in subsequent country subclasses.
+    def translate_number(self):
+        return self.plate_number
     
 # Sweden is a subclass of LicensePlate. I have included a constructor method for this purpose.
 # Swedish plates are comprised of three letters a space and three numbers e.g: WNF 864.
@@ -41,16 +45,14 @@ class Sweden(LicensePlate):
     def __init__(self):
         country = 'Sweden' # duh
         plate_number = random_letter() + random_letter() + random_letter() + " " + random_number() + random_number() + random_number()
+
         super().__init__(plate_number,country)
 
+    def translate_number(self):
+        return self.plate_number[0:4] + number_sw(int(self.plate_number[4:]))
+    
     def image_plate(self):
         create_swedish_plate(self.plate_number)
-
-    def dict_sw(self):
-        countrySW = country_sw(self.country)
-        numberSW = self.plate_number[0:4] + number_sw(int(self.plate_number[4:]))
-        return {'country':countrySW,
-                'number':numberSW}
 
 # Ukraine is another subclass of LicensePlate.
 # Ukranian plates are comprised of two letters, a space, four numbers, another space, and two letters e.g: AK 9265 AK
@@ -60,17 +62,15 @@ class Ukraine(LicensePlate):
     def __init__(self):
         country = 'Ukraine'  
         plate_number = ukranian_plate_gen()
+        
         super().__init__(plate_number,country)
 
     def image_plate(self):
         create_ukrainian_plate(self.plate_number)
     
-    def dict_sw(self):
-        countrySW = country_sw(self.country)
-        numberSW = self.plate_number[0:3] + number_sw(int(self.plate_number[3:7])) + self.plate_number[7:]
-        return {'country':countrySW,
-                'number':numberSW}  
-
+    def translate_number(self):
+        return self.plate_number[0:3] + number_sw(int(self.plate_number[3:7])) + self.plate_number[7:]
+        
 
 # Roamania is another subclass of LicensePlate.
 # Romanian plates are comprised of two letters, a space, two numbers, another space, and three letters. e.g: BN 18 CTL
@@ -84,12 +84,10 @@ class Romania(LicensePlate):
     def image_plate(self):
         create_romanian_plate(self.plate_number)
     
-    def dict_sw(self):
-        countrySW = country_sw(self.country)
+    def translate_number(self):
         numarrays = self.plate_number.split()
-        numberSW = numarrays[0] + ' ' + number_sw(int(numarrays[1])) + ' ' + numarrays[2]
-        return {'country':countrySW,
-                'number':numberSW}
+        return numarrays[0] + ' ' + number_sw(int(numarrays[1])) + ' ' + numarrays[2]
+        
 
 
 
@@ -104,11 +102,9 @@ class Estonia(LicensePlate):
     def image_plate(self):
         create_estonian_plate(self.plate_number)
 
-    def dict_sw(self): 
-        countrySW = country_sw(self.country)
-        numberSW = self.plate_number[0:4] + number_sw(int(self.plate_number[4:]))
-        return {'country': countrySW,
-                'number': numberSW}
+    def translate_number(self): 
+        return self.plate_number[0:4] + number_sw(int(self.plate_number[4:]))
+        
     
 # Bulgaria is another subclass of LicensePlate.
 # Bulgarian plates have a one to two letter regional code, followed by a four digit serial number, and a two letter code called a series
@@ -123,14 +119,10 @@ class Bulgaria(LicensePlate):
     def image_plate(self):
         create_bulgarian_plate(self.plate_number)
     
-    def dict_sw(self):
-        countrySW = country_sw(self.country)
-        # print(countrySW)
+    def translate_number(self):
         numarrays =  self.plate_number.split()
-        numberSW = numarrays[0] + ' ' + number_sw(int(numarrays[1])) + ' ' + numarrays[2]
-        return {'country': countrySW,
-                'number': numberSW}
-    
+        return numarrays[0] + ' ' + number_sw(int(numarrays[1])) + ' ' + numarrays[2]
+        
 # Bosnia and Herzegovina (referred to as Bosnia for simplicity hereonafter) is another subclass of LicensePlate
 # Bosnian plates have five numbers and two letters in the order "X00-X-000". There are no regional codes.
 #  https://en.wikipedia.org/wiki/Vehicle_registration_plates_of_Bosnia_and_Herzegovina
@@ -149,12 +141,10 @@ class Bosnia(LicensePlate):
     def image_plate(self):
         create_bosnian_plate(self.plate_number)
     
-    def dict_sw(self):
-        countrySW = country_sw(self.country)
+    def translate_number(self):
         numarrays = self.plate_number.split('-')
-        numberSW = numarrays[0][0] + ' ' + number_sw(int(numarrays[0][1:])) + ' ' + numarrays[1] + ' ' + number_sw(int(numarrays[2]))
-        return {'country': countrySW,
-                'number': numberSW}
+        return numarrays[0][0] + ' ' + number_sw(int(numarrays[0][1:])) + ' ' + numarrays[1] + ' ' + number_sw(int(numarrays[2]))
+        
     
 # Malta is a subclass of LicensePlate.
 # Maltese plates have three letters and three numbers (ZZZ 999). There are no regional codes.
@@ -170,20 +160,14 @@ class Malta(LicensePlate):
     def image_plate(self):
         create_maltese_plate(self.plate_number)
     
-    def dict_sw(self):
-        countrySW = country_sw(self.country)
+    def translate_number(self):
         numarrays = self.plate_number.split()
 
         numberSW = ''
         if numarrays[0] == 'TAXI':
-            numberSW = numarrays[0] + ' ' +  number_sw(int(numarrays[1][:-1])) + ' ' + numarrays[-1]
-            return {'country': countrySW,
-                    'number': numberSW}
+            return numarrays[0] + ' ' +  number_sw(int(numarrays[1][:-1])) + ' ' + numarrays[-1]
         
-        numberSW = numarrays[0] + ' ' + number_sw(int(numarrays[1]))
-
-        return {'country': countrySW,
-                'number': numberSW}
+        return numarrays[0] + ' ' + number_sw(int(numarrays[1]))
 
 
 # Belgium is a subclass of LicensePlate
@@ -201,13 +185,9 @@ class Belgium(LicensePlate):
     def image_plate(self):
         create_belgian_plate(self.plate_number)
     
-    def dict_sw(self):
-        countrySW = country_sw(self.country)
+    def translate_number(self):
         numarrays = self.plate_number.split('-')
-
-        numberSW = number_sw(int(numarrays[0])) + ' ' + numarrays[1] + ' ' + number_sw(int(numarrays[2]))
-        return {'country': countrySW,
-                'number': numberSW}
+        return number_sw(int(numarrays[0])) + ' ' + numarrays[1] + ' ' + number_sw(int(numarrays[2]))
     
 # Spain is a subclass of LicensePlate.
 # format is 0000 CCC comprising of consanants only. C is a series where the first letter is from A-M as of 2022.
@@ -222,12 +202,8 @@ class Spain(LicensePlate):
     def image_plate(self):
         create_spanish_plate(self.plate_number)
     
-    def dict_sw(self):
-        countrySW = country_sw(self.country)
-        numberSW = number_sw(int(self.plate_number[:4])) + ' ' + self.plate_number[5:]
-
-        return {'country':countrySW,
-                'number': numberSW}
+    def translate_number(self):
+        return number_sw(int(self.plate_number[:4])) + ' ' + self.plate_number[5:]
 
 # Slovakia is a subclass of LicensePlate
 # the format is XX  000XX where the first two letters are a district code and per district
@@ -243,13 +219,9 @@ class Slovakia(LicensePlate):
     def image_plate(self):
         create_slovakian_plate(self.plate_number)
     
-    def dict_sw(self):
-        countrySW = country_sw(self.country)
+    def translate_number(self):
         numarrays = self.plate_number.split(' ')
-        numberSW = numarrays[0] + ' ' + number_sw(int(numarrays[1][0:3])) + ' ' + numarrays[1][3:]
-
-        return {'country':countrySW,
-                'number':numberSW}
+        return numarrays[0] + ' ' + number_sw(int(numarrays[1][0:3])) + ' ' + numarrays[1][3:]
     
 
 # Cyprus is a subclass of LicensePlate
@@ -265,14 +237,9 @@ class Cyprus(LicensePlate):
     def image_plate(self):
         create_cypriot_plate(self.plate_number)
 
-    def dict_sw(self):
-        countrySW = country_sw(self.country)
+    def translate_number(self):
         numarrays = self.plate_number.split()
-        numberSW = numarrays[0] + ' ' + number_sw(int(numarrays[1])) 
-
-        return {'country':countrySW,
-                'number':numberSW}
-    
+        return numarrays[0] + ' ' + number_sw(int(numarrays[1])) 
 
     
     

--- a/plate.py
+++ b/plate.py
@@ -27,6 +27,7 @@ class LicensePlate:
         self.vehicle = 'car' # making every vehicle a car for now. May add support to bikes in the future.
         self.dictsw = {
             'country':country_sw(self.country),
+            'country_adj':country_sw(self.country,'adjective'),
             'number':self.translate_number()
         }
     

--- a/plate.py
+++ b/plate.py
@@ -2,10 +2,10 @@
 import random
 import string
 from plate_imager import (
-    create_swedish_plate, create_ukrainian_plate, create_romanian_plate, 
-    create_estonian_plate, create_bulgarian_plate, create_bosnian_plate,
-    create_maltese_plate, create_belgian_plate, create_spanish_plate,
-    create_slovakian_plate, create_cypriot_plate
+    create_sweden_plate, create_ukraine_plate, create_romania_plate, 
+    create_estonia_plate, create_bulgaria_plate, create_bosnia_plate,
+    create_malta_plate, create_belgium_plate, create_spain_plate,
+    create_slovakia_plate, create_cyprus_plate
 )
 from translator import country_sw, number_sw
 from plate_gen import (
@@ -38,6 +38,13 @@ class LicensePlate:
     def translate_number(self):
         return self.plate_number
     
+    def image_plate(self):
+        func_name = f'create_{self.country.lower()}_plate'
+        if func_name in globals():
+            return globals()[func_name](self.plate_number)
+        else:
+            raise NotImplementedError(f"No image creation function named: {func_name}")
+    
 # Sweden is a subclass of LicensePlate. I have included a constructor method for this purpose.
 # Swedish plates are comprised of three letters a space and three numbers e.g: WNF 864.
 # They also use the DIN 1451 font https://en.wikipedia.org/wiki/DIN_1451.
@@ -50,10 +57,7 @@ class Sweden(LicensePlate):
 
     def translate_number(self):
         return self.plate_number[0:4] + number_sw(int(self.plate_number[4:]))
-    
-    def image_plate(self):
-        create_swedish_plate(self.plate_number)
-
+  
 # Ukraine is another subclass of LicensePlate.
 # Ukranian plates are comprised of two letters, a space, four numbers, another space, and two letters e.g: AK 9265 AK
 # https://upload.wikimedia.org/wikipedia/commons/7/77/License_plate_of_Ukraine_2015.png 
@@ -65,9 +69,6 @@ class Ukraine(LicensePlate):
         
         super().__init__(plate_number,country)
 
-    def image_plate(self):
-        create_ukrainian_plate(self.plate_number)
-    
     def translate_number(self):
         return self.plate_number[0:3] + number_sw(int(self.plate_number[3:7])) + self.plate_number[7:]
         
@@ -81,9 +82,6 @@ class Romania(LicensePlate):
         plate_number = romanian_plate_gen()
         super().__init__(plate_number,country)
 
-    def image_plate(self):
-        create_romanian_plate(self.plate_number)
-    
     def translate_number(self):
         numarrays = self.plate_number.split()
         return numarrays[0] + ' ' + number_sw(int(numarrays[1])) + ' ' + numarrays[2]
@@ -99,9 +97,6 @@ class Estonia(LicensePlate):
         plate_number = random_letter() + random_letter() + random_letter() + " " + random_number() + random_number() + random_number()
         super().__init__(plate_number,country)
 
-    def image_plate(self):
-        create_estonian_plate(self.plate_number)
-
     def translate_number(self): 
         return self.plate_number[0:4] + number_sw(int(self.plate_number[4:]))
         
@@ -115,9 +110,6 @@ class Bulgaria(LicensePlate):
         country = 'Bulgaria'
         plate_number = bulgarian_plate_gen()
         super().__init__(plate_number,country)
-    
-    def image_plate(self):
-        create_bulgarian_plate(self.plate_number)
     
     def translate_number(self):
         numarrays =  self.plate_number.split()
@@ -138,9 +130,6 @@ class Bosnia(LicensePlate):
         
         super().__init__(plate_number, country)
     
-    def image_plate(self):
-        create_bosnian_plate(self.plate_number)
-    
     def translate_number(self):
         numarrays = self.plate_number.split('-')
         return numarrays[0][0] + ' ' + number_sw(int(numarrays[0][1:])) + ' ' + numarrays[1] + ' ' + number_sw(int(numarrays[2]))
@@ -156,9 +145,6 @@ class Malta(LicensePlate):
         plate_number = maltese_plate_gen()
 
         super().__init__(plate_number, country)
-    
-    def image_plate(self):
-        create_maltese_plate(self.plate_number)
     
     def translate_number(self):
         numarrays = self.plate_number.split()
@@ -182,9 +168,6 @@ class Belgium(LicensePlate):
         
         super().__init__(plate_number,country)
     
-    def image_plate(self):
-        create_belgian_plate(self.plate_number)
-    
     def translate_number(self):
         numarrays = self.plate_number.split('-')
         return number_sw(int(numarrays[0])) + ' ' + numarrays[1] + ' ' + number_sw(int(numarrays[2]))
@@ -199,9 +182,6 @@ class Spain(LicensePlate):
 
         super().__init__(plate_number,country)
 
-    def image_plate(self):
-        create_spanish_plate(self.plate_number)
-    
     def translate_number(self):
         return number_sw(int(self.plate_number[:4])) + ' ' + self.plate_number[5:]
 
@@ -216,9 +196,7 @@ class Slovakia(LicensePlate):
 
         super().__init__(plate_number,country)
 
-    def image_plate(self):
-        create_slovakian_plate(self.plate_number)
-    
+ 
     def translate_number(self):
         numarrays = self.plate_number.split(' ')
         return numarrays[0] + ' ' + number_sw(int(numarrays[1][0:3])) + ' ' + numarrays[1][3:]
@@ -234,9 +212,6 @@ class Cyprus(LicensePlate):
 
         super().__init__(plate_number,country)
     
-    def image_plate(self):
-        create_cypriot_plate(self.plate_number)
-
     def translate_number(self):
         numarrays = self.plate_number.split()
         return numarrays[0] + ' ' + number_sw(int(numarrays[1])) 

--- a/plate_imager.py
+++ b/plate_imager.py
@@ -13,6 +13,7 @@ smallplate_countries = ['sverige','estland']
 # creates the back end of the plates, as in the solutions to the flashcard
 def back_matter(plate_number,dictsw):
     country = dictsw['country']
+    countryadj = dictsw['country_adj']
     number = dictsw['number']
 
     width, height = LARGEPLATE_WIDTH, PLATE_HEIGHT
@@ -26,7 +27,7 @@ def back_matter(plate_number,dictsw):
     image = Image.new('RGB', (width,height), color = 'white')
     draw = ImageDraw.Draw(image)
 
-    text = f'land: {country}\nnummer: {number}'
+    text = f'detta är en {countryadj} bil.\nland: {country}\nnummer: {number}'
     font = ImageFont.truetype('fonts/Trebuchet MS.ttf', size=size)
     
     bbox = draw.textbbox((0,0),text,font=font)

--- a/plate_imager.py
+++ b/plate_imager.py
@@ -40,7 +40,7 @@ def back_matter(plate_number,dictsw):
     image.save(f'plate-outputs/{plate_number}-back.png')
     
 # example create a Swedish plate
-def create_swedish_plate(number):
+def create_sweden_plate(number):
     image = Image.open("plate-templates/sweden.png").convert('RGBA')
     draw = ImageDraw.Draw(image)
     font = ImageFont.truetype("fonts/DINMittelschriftStd.otf",size=170)
@@ -56,7 +56,7 @@ def create_swedish_plate(number):
 
 # could not find a reputable source for what font Ukraine uses on their plates.
 # some Redditor mentioned that the closest font to it is Motor4F https://www.reddit.com/r/identifythisfont/comments/ug5e1o/hey_does_anyone_know_where_i_could_get_the/
-def create_ukrainian_plate(number):
+def create_ukraine_plate(number):
     image = Image.open("plate-templates/ukrainelg.png").convert('RGBA')
     draw = ImageDraw.Draw(image)
     font = ImageFont.truetype("fonts/Motor4F.otf",size=200)
@@ -72,7 +72,7 @@ def create_ukrainian_plate(number):
 
 # according to Wikipedia, Romania like Sweden uses the DIN 1451 Mittelschrift font
 # https://en.wikipedia.org/wiki/Vehicle_registration_plates_of_Romania
-def create_romanian_plate(number):
+def create_romania_plate(number):
     image = Image.open("plate-templates/romanialg.png").convert('RGBA')
     draw = ImageDraw.Draw(image)
     font = ImageFont.truetype("fonts/DINMittelschriftStd.otf",size=200)
@@ -90,7 +90,7 @@ def create_romanian_plate(number):
     # image.show()
 
 # I could not find any information for what font Estonia uses for their plates.  From what it looks like, I would suspect they are using the DIN font too.
-def create_estonian_plate(number):
+def create_estonia_plate(number):
     image = Image.open("plate-templates/estonia.png").convert('RGBA')
     draw = ImageDraw.Draw(image)
     font = ImageFont.truetype("fonts/DINMittelschriftStd.otf",size=180)
@@ -105,7 +105,7 @@ def create_estonian_plate(number):
     image.save(f"plate-outputs/{number}-front.png")
     # image.show()
 
-def create_bulgarian_plate(number):
+def create_bulgaria_plate(number):
     image = Image.open("plate-templates/bulgaria.png").convert('RGBA')
     draw = ImageDraw.Draw(image)
     font = ImageFont.truetype("fonts/Bulgarianmarijanovic-Regular.ttf",size=200)
@@ -121,7 +121,7 @@ def create_bulgarian_plate(number):
 # Bosnian plates use the FE-Schrift font, as seen by the white line in the 0 
 # https://en.wikipedia.org/wiki/European_vehicle_registration_plate#/media/File:License_plate_Bosnia_and_Herzegowina_2009.jpg
 
-def create_bosnian_plate(number):
+def create_bosnia_plate(number):
     image = Image.open("plate-templates/bosnia.png").convert('RGBA')
     draw = ImageDraw.Draw(image)
     font = ImageFont.truetype("fonts/FE-FONT.TTF",size=180)
@@ -135,7 +135,7 @@ def create_bosnian_plate(number):
     image.save(f"plate-outputs/{number}-front.png")
 
 # Maltese plates use FE-Schrift too
-def create_maltese_plate(number):
+def create_malta_plate(number):
     image = Image.open("plate-templates/malta.png").convert('RGBA')
     draw = ImageDraw.Draw(image)
     font = ImageFont.truetype("fonts/FE-FONT.TTF",size=200)
@@ -155,7 +155,7 @@ def create_maltese_plate(number):
 
 
 # Belgian plates have dark red text (#882329). They use a unique font that I do not want to pay for. The closest thing to it is  DIN1451
-def create_belgian_plate(number):
+def create_belgium_plate(number):
     image = Image.open("plate-templates/belgium.png").convert('RGBA')
     draw = ImageDraw.Draw(image)
     font = ImageFont.truetype("fonts/DINMittelschriftStd.otf",size=220)
@@ -168,7 +168,7 @@ def create_belgian_plate(number):
     image.save(f"plate-outputs/{number}-front.png")
 
 # Spain uses a font similar to DIN 1451: https://www.leewardpro.com/articles/licplatefonts/licplate-fonts-eur-2.html#:~:text=Spain,is%20modeled%20after%20DIN%201451.
-def create_spanish_plate(number):
+def create_spain_plate(number):
     image = Image.open("plate-templates/spain.png").convert('RGBA')
     draw = ImageDraw.Draw(image)
     font = ImageFont.truetype("fonts/DINMittelschriftStd.otf",size=220)
@@ -183,7 +183,7 @@ def create_spanish_plate(number):
 
 # Slovakia uses its own font that I am using a copy developed by /u/Marijanovic on Reddit.
 # The Slovakian plates have a seal of the country after the provincial code
-def create_slovakian_plate(number):
+def create_slovakia_plate(number):
     image = Image.open('plate-templates/slovakia.png').convert('RGBA')
     draw = ImageDraw.Draw(image)
     font = ImageFont.truetype('fonts/slovakiaMarijanovic.ttf',size=220)
@@ -199,7 +199,7 @@ def create_slovakian_plate(number):
 
 # Cyprus uses FE SCHRIFT. They also have the registration date on the plate in DIN font.
 # Since the new series of plates started in 2013 I will make the year from 2013-2025
-def create_cypriot_plate(number):
+def create_cyprus_plate(number):
     image = Image.open("plate-templates/cyprus.png").convert('RGBA')
     draw = ImageDraw.Draw(image)
     font = ImageFont.truetype("fonts/FE-FONT.TTF",size=200)

--- a/swedish-translations/countries.yaml
+++ b/swedish-translations/countries.yaml
@@ -1,13 +1,29 @@
 # swedish translations for countries, courtesy of Google Maps. YAML files are like JSON but more human readable. Parsed by pyyaml 
 countries:
-  sweden: Sverige
-  ukraine: Ukraina 
-  estonia: Estland
-  romania: Rumänien
-  bulgaria: Bulgarien
-  bosnia: Bosnien och Hercegovina
-  malta: Malta
-  belgium: Belgien
-  spain: Spanien
-  slovakia: Slovakien
-  cyprus: Cypern
+  noun:
+    sweden: Sverige
+    ukraine: Ukraina 
+    estonia: Estland
+    romania: Rumänien
+    bulgaria: Bulgarien
+    bosnia: Bosnien och Hercegovina
+    malta: Malta
+    belgium: Belgien
+    spain: Spanien
+    slovakia: Slovakien
+    cyprus: Cypern
+  adjective:
+    sweden: svensk
+    ukraine: ukrainsk
+    estonia: estnisk
+    romania: rumänsk
+    bulgaria: bulgarisk
+    bosnia: bosnisk 
+    malta: maltesisk 
+    belgium: belgisk
+    spain: spansk
+    slovakia: slovakisk
+    cyprus: cypriotisk
+
+
+

--- a/tests/misc_tests.py
+++ b/tests/misc_tests.py
@@ -1,0 +1,18 @@
+import sys
+import os
+import yaml
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))) # chatGPT method to import outside of the directory
+
+import pytest
+import plate_imager
+
+with open('swedish-translations/countries.yaml') as file:
+    data = yaml.safe_load(file)
+
+countries = list(data['countries'].keys())
+
+@pytest.mark.parametrize("country", countries)
+def test_create_plate_function_exists(country):
+    func_name = f'create_{country.lower()}_plate'
+    assert hasattr(plate_imager, func_name), f"Missing function: {func_name}"
+    assert callable(getattr(plate_imager, func_name)), f"{func_name} is not callable"

--- a/tests/misc_tests.py
+++ b/tests/misc_tests.py
@@ -9,7 +9,7 @@ import plate_imager
 with open('swedish-translations/countries.yaml') as file:
     data = yaml.safe_load(file)
 
-countries = list(data['countries'].keys())
+countries = list(data['countries']['noun'].keys())
 
 @pytest.mark.parametrize("country", countries)
 def test_create_plate_function_exists(country):

--- a/tests/test_translator.py
+++ b/tests/test_translator.py
@@ -45,6 +45,8 @@ def test_country_plateclass():
     country = cypriotplate.country
     assert country_sw(country) == 'Cypern'
 
+    assert cypriotplate.dictsw['country'] == 'Cypern'
+
 def test_unknown_country():
     assert country_sw('Mali') is None
 

--- a/tests/test_translator.py
+++ b/tests/test_translator.py
@@ -45,7 +45,7 @@ def test_country_plateclass():
     country = cypriotplate.country
     assert country_sw(country) == 'Cypern'
 
-    assert cypriotplate.dictsw['country'] == 'Cypern'
+    assert cypriotplate.dictsw['country'] == 'Cypern' # yay new system works
 
 def test_unknown_country():
     assert country_sw('Mali') is None

--- a/translator.py
+++ b/translator.py
@@ -1,16 +1,15 @@
 import yaml
 
 # gives the Swedish translation of a country (string). List of supported countries read by swedish-translations/countries.yaml
-def country_sw(country):
+def country_sw(country,type='noun'):
     country = country.lower()
     with open('swedish-translations/countries.yaml') as file:
         data = yaml.safe_load(file)
-    
-    data = data['countries']
-    if country not in data:
-        return None 
-     
-    return data[country]
+        
+    if type not in list(data['countries'].keys()):
+        raise ValueError('Invalid type. Must be a \'noun\' or \'adjective\'.')
+ 
+    return data['countries'].get(type,{}).get(country)
 
 # supports up to four digit numbers. May handle more in the future if necessary
 def number_sw(num):
@@ -62,4 +61,4 @@ def number_sw(num):
 
     return returnstr
             
-            
+          


### PR DESCRIPTION
removes redundancies in plate.py. The image_plate() class is constructed in super and is no longer present in subclasses. Same applies for dict_sw().

Most impactful is the change to the flash cards. There is now a line at the beginning of the back of the cards saying "this is a Maltese plate" for example:
<img width="1165" alt="image" src="https://github.com/user-attachments/assets/d46d1250-14b7-42be-ad4f-f038ece5cd0a" />
